### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN apt-get update && \
     chmod +x /usr/bin/winetricks && \
     rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p $HOME/prefix \
+    && chown -R wineuser:wineuser $HOME
+
 ADD blueiris.sh $HOME/blueiris.sh
 ADD service.reg $HOME/service.reg
 ADD launch_blueiris.sh $HOME/launch_blueiris.sh


### PR DESCRIPTION
fixes the prefix ownership issue preventing blueiris from installing